### PR TITLE
Fix repeated listeners in useToast

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid accumulating listeners on each state update by using an empty effect dependency list in `useToast`

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_b_688b2070e0708331bf594c65a6484e77